### PR TITLE
Refactor/herencia en benchmark settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@
 
 # Build
 build/
+obj/

--- a/include/benchmark_scheme.hpp
+++ b/include/benchmark_scheme.hpp
@@ -14,7 +14,7 @@ public:
     int world_size, world_rank;
 
     // Settings based on args
-    settings::benchmark_settings settings;
+    BenchmarkSettings settings;
 
     // Timer wrapper with time measurements
     benchmark_timer timer;

--- a/include/benchmark_scheme.hpp
+++ b/include/benchmark_scheme.hpp
@@ -14,13 +14,14 @@ public:
     int world_size, world_rank;
 
     // Settings based on args
-    BenchmarkSettings settings;
+    BenchmarkSettings *settings;
 
     // Timer wrapper with time measurements
     benchmark_timer timer;
 
-    BenchmarkScheme() = default;
-    virtual ~BenchmarkScheme() = default;
+    BenchmarkScheme() : settings(new BenchmarkSettings()){};
+    BenchmarkScheme(BenchmarkSettings *settings) : settings(settings) {}
+    virtual ~BenchmarkScheme();
 
     // Initialize all data needed
     virtual void init(int argc, char *argv[]);

--- a/include/benchmark_settings.hpp
+++ b/include/benchmark_settings.hpp
@@ -4,40 +4,138 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <regex>
 
-namespace settings
+// Helper function to convert a string representation of bytes to an integer
+static std::optional<int> parseBytes(const std::string &arg)
 {
+    std::regex regex(R"((\d+)(([KMG]B?)|B))");
+    std::smatch match;
+
+    if (std::regex_match(arg, match, regex))
+    {
+        int value = std::stoi(match[1]);
+        std::string unit = match[2];
+
+        if (unit.at(0) == 'K')
+            value *= 1024;
+        else if (unit.at(0) == 'M')
+            value *= 1024 * 1024;
+        else if (unit.at(0) == 'G')
+            value *= 1024 * 1024 * 1024;
+        else if (unit.empty())
+            return std::nullopt;
+
+        return value;
+    }
+
+    return std::nullopt;
+}
+
+class BenchmarkSettings
+{
+public:
     // Output mode enum
-    enum class output_mode
+    enum class OutputMode
     {
         none,
         verbose,
         quiet
     };
 
-    // Options struct
-    struct benchmark_settings
-    {
-        // bool help{false};
-        // bool verbose{false};
-        output_mode o_mode{output_mode::none};
-        std::optional<std::string> raw_value;
-        std::optional<int> value;
-        bool isByteValue{false};
-        std::optional<u_int32_t> repetitions;
-        bool warmup{true};
-        std::optional<u_int32_t> warmup_repetitions;
-    };
+    // bool help{false};
+    // bool verbose{false};
+    OutputMode o_mode{OutputMode::none};
+    std::optional<std::string> raw_value;
+    std::optional<int> value;
+    bool isByteValue{false};
+    std::optional<u_int32_t> repetitions;
+    bool warmup{true};
+    std::optional<u_int32_t> warmup_repetitions;
 
-    typedef std::function<void(benchmark_settings &)> NoArgHandle;
+    typedef std::function<void(BenchmarkSettings &)> NoArgHandle;
+// No argument flag behavior
+#define S(str, f, v)                               \
+    {                                              \
+        str, [](BenchmarkSettings &s) { s.f = v; } \
+    }
+
     // No argument flag behavior
-    extern const std::unordered_map<std::string, NoArgHandle> NoArgs;
+    std::unordered_map<std::string, NoArgHandle> NoArgs{
+        // S("--help", help, true),
+        // S("-h", help, true),
 
-    typedef std::function<void(benchmark_settings &, const std::string &)> OneArgHandle;
+        // S("--verbose", verbose, true),
+        // S("-v", verbose, true),
+
+        S("--quiet", o_mode, BenchmarkSettings::OutputMode::quiet),
+        S("-q", o_mode, BenchmarkSettings::OutputMode::quiet),
+
+        S("--no-warmup", warmup, false),
+    };
+#undef S
+
+    typedef std::function<void(BenchmarkSettings &, const std::string &)> OneArgHandle;
+
+#define S(str, f, v)                                                       \
+    {                                                                      \
+        str, [](BenchmarkSettings &s, const std::string &arg) { s.f = v; } \
+    }
+
     // One argument flag behavior
-    extern const std::unordered_map<std::string, OneArgHandle> OneArgs;
+    std::unordered_map<std::string, OneArgHandle> OneArgs{
+
+        // Performing string -> int conversion
+        {"--value", [](BenchmarkSettings &s, const std::string &arg)
+         {
+             s.raw_value = arg;
+             std::optional<int> value = parseBytes(arg);
+             if (value.has_value())
+             {
+                 s.isByteValue = true;
+                 s.value = value;
+             }
+             else
+             {
+                 s.isByteValue = false;
+                 s.value = stoi(arg);
+             }
+
+             if (s.value <= 0)
+             {
+                 throw std::runtime_error{"value must be a positive integer"};
+             }
+         }},
+
+        // Performing string -> int conversion
+        {"--repetitions", [](BenchmarkSettings &s, const std::string &arg)
+         {
+             int reps_arg = stoi(arg);
+             if (reps_arg > 0)
+             {
+                 s.repetitions = reps_arg;
+             }
+             else
+             {
+                 throw std::runtime_error{"repetitions must be a positive integer"};
+             }
+         }},
+        // Performing string -> int conversion
+        {"--warmup-repetitions", [](BenchmarkSettings &s, const std::string &arg)
+         {
+             int reps_arg = stoi(arg);
+             if (reps_arg > 0)
+             {
+                 s.warmup_repetitions = reps_arg;
+             }
+             else
+             {
+                 throw std::runtime_error{"repetitions must be a positive integer"};
+             }
+         }},
+    };
+#undef S
 
     // Parse the command line arguments
-    benchmark_settings parse_settings(int argc, const char *argv[]);
-
-} // namespace settings
+    void parse_settings(int argc, const char *argv[]);
+};

--- a/include/benchmark_timer.hpp
+++ b/include/benchmark_timer.hpp
@@ -13,13 +13,13 @@ private:
 
     std::vector<double> m_times;
 
-    settings::benchmark_settings *m_settings;
+    BenchmarkSettings *m_settings;
 
 public:
-    benchmark_timer(settings::benchmark_settings *p_settings = nullptr);
-    benchmark_timer(const int32_t p_size, settings::benchmark_settings *p_settings = nullptr);
+    benchmark_timer(BenchmarkSettings *p_settings = nullptr);
+    benchmark_timer(const int32_t p_size, BenchmarkSettings *p_settings = nullptr);
 
-    void set_settings(settings::benchmark_settings *p_settings);
+    void set_settings(BenchmarkSettings *p_settings);
 
     void reserve(const int32_t p_size);
 

--- a/include/mpi_benchmark_scheme.hpp
+++ b/include/mpi_benchmark_scheme.hpp
@@ -6,6 +6,7 @@ class MpiBenchmarkScheme : public BenchmarkScheme
 {
 public:
     MpiBenchmarkScheme() = default;
+    MpiBenchmarkScheme(BenchmarkSettings *settings) : BenchmarkScheme(settings){};
     virtual ~MpiBenchmarkScheme() = default;
 
     virtual void init(int argc, char *argv[]) override;

--- a/include/upcxx_benchmark_scheme.hpp
+++ b/include/upcxx_benchmark_scheme.hpp
@@ -6,6 +6,7 @@ class UpcxxBenchmarkScheme : public BenchmarkScheme
 {
 public:
     UpcxxBenchmarkScheme() = default;
+    UpcxxBenchmarkScheme(BenchmarkSettings *settings) : BenchmarkScheme(settings){};
     virtual ~UpcxxBenchmarkScheme() = default;
 
     virtual void init(int argc, char *argv[]) override;

--- a/lib/benchmark_scheme.cpp
+++ b/lib/benchmark_scheme.cpp
@@ -1,34 +1,39 @@
 #include <benchmark_scheme.hpp>
 
+BenchmarkScheme::~BenchmarkScheme()
+{
+    delete settings;
+}
+
 void BenchmarkScheme::init(int argc, char *argv[])
 {
-    settings.parse_settings(argc, const_cast<const char **>(argv));
-    if (settings.value.has_value())
+    settings->parse_settings(argc, const_cast<const char **>(argv));
+    if (settings->value.has_value())
     {
-        if (settings.isByteValue)
+        if (settings->isByteValue)
         {
-            number_count = settings.value.value();
+            number_count = settings->value.value();
         }
         else
         {
-            number_count = settings.value.value();
+            number_count = settings->value.value();
         }
     }
 
-    if (settings.repetitions.has_value())
+    if (settings->repetitions.has_value())
     {
-        reps = settings.repetitions.value();
+        reps = settings->repetitions.value();
     }
 
-    if (settings.warmup_repetitions.has_value())
+    if (settings->warmup_repetitions.has_value())
     {
-        warmup_repetitions = settings.warmup_repetitions.value();
+        warmup_repetitions = settings->warmup_repetitions.value();
     }
 
     if (world_rank == 0)
     {
         timer.reserve(reps);
-        timer.set_settings(&settings);
+        timer.set_settings(settings);
     }
 }
 
@@ -70,7 +75,7 @@ void BenchmarkScheme::run(int argc, char *argv[])
 
     init(argc, argv);
 
-    if (settings.warmup)
+    if (settings->warmup)
     {
         for (uint32_t i = 0; i < warmup_repetitions; i++)
         {

--- a/lib/benchmark_scheme.cpp
+++ b/lib/benchmark_scheme.cpp
@@ -2,7 +2,7 @@
 
 void BenchmarkScheme::init(int argc, char *argv[])
 {
-    settings = settings::parse_settings(argc, const_cast<const char **>(argv));
+    settings.parse_settings(argc, const_cast<const char **>(argv));
     if (settings.value.has_value())
     {
         if (settings.isByteValue)

--- a/lib/benchmark_timer.cpp
+++ b/lib/benchmark_timer.cpp
@@ -4,17 +4,17 @@
 #include <iostream>
 #include <numeric>
 
-benchmark_timer::benchmark_timer(settings::benchmark_settings *p_settings)
+benchmark_timer::benchmark_timer(BenchmarkSettings *p_settings)
 {
     m_settings = p_settings;
 }
-benchmark_timer::benchmark_timer(const int32_t p_size, settings::benchmark_settings *p_settings)
+benchmark_timer::benchmark_timer(const int32_t p_size, BenchmarkSettings *p_settings)
 {
     m_times.reserve(p_size);
     m_settings = p_settings;
 }
 
-void benchmark_timer::set_settings(settings::benchmark_settings *p_settings)
+void benchmark_timer::set_settings(BenchmarkSettings *p_settings)
 {
     m_settings = p_settings;
 }
@@ -43,7 +43,7 @@ void benchmark_timer::add_time()
 
 void benchmark_timer::print_times()
 {
-    if (m_settings->o_mode == settings::output_mode::none)
+    if (m_settings->o_mode == BenchmarkSettings::OutputMode::none)
     {
         if (m_settings->raw_value)
             std::cout << "Count: " << m_settings->raw_value.value() << std::endl;
@@ -61,7 +61,7 @@ void benchmark_timer::print_times()
             std::cout << std::endl;
         }
     }
-    else if (m_settings->o_mode == settings::output_mode::quiet)
+    else if (m_settings->o_mode == BenchmarkSettings::OutputMode::quiet)
     {
         if (!m_times.empty())
         {

--- a/lib/benchmarks_settings.cpp
+++ b/lib/benchmarks_settings.cpp
@@ -1,133 +1,22 @@
 #include <benchmark_settings.hpp>
 
-#include <iostream>
-#include <stdexcept>
-#include <regex>
-
-// Helper function to convert a string representation of bytes to an integer
-static std::optional<int> parseBytes(const std::string &arg)
-{
-    std::regex regex(R"((\d+)(([KMG]B?)|B))");
-    std::smatch match;
-
-    if (std::regex_match(arg, match, regex))
-    {
-        int value = std::stoi(match[1]);
-        std::string unit = match[2];
-
-        if (unit.at(0) == 'K')
-            value *= 1024;
-        else if (unit.at(0) == 'M')
-            value *= 1024 * 1024;
-        else if (unit.at(0) == 'G')
-            value *= 1024 * 1024 * 1024;
-        else if (unit.empty())
-            return std::nullopt;
-
-        return value;
-    }
-
-    return std::nullopt;
-}
-
-#define S(str, f, v)                                          \
-    {                                                         \
-        str, [](settings::benchmark_settings &s) { s.f = v; } \
-    }
-
-// No argument flag behavior
-const std::unordered_map<std::string, settings::NoArgHandle> settings::NoArgs{
-    // S("--help", help, true),
-    // S("-h", help, true),
-
-    // S("--verbose", verbose, true),
-    // S("-v", verbose, true),
-
-    S("--quiet", o_mode, settings::output_mode::quiet),
-    S("-q", o_mode, settings::output_mode::quiet),
-
-    S("--no-warmup", warmup, false),
-};
-#undef S
-
-#define S(str, f, v)                                                                  \
-    {                                                                                 \
-        str, [](settings::benchmark_settings &s, const std::string &arg) { s.f = v; } \
-    }
-
-// One argument flag behavior
-const std::unordered_map<std::string, settings::OneArgHandle> settings::OneArgs{
-
-    // Performing string -> int conversion
-    {"--value", [](settings::benchmark_settings &s, const std::string &arg)
-     {
-         s.raw_value = arg;
-         std::optional<int> value = parseBytes(arg);
-         if (value.has_value())
-         {
-             s.isByteValue = true;
-             s.value = value;
-         }
-         else
-         {
-             s.isByteValue = false;
-             s.value = stoi(arg);
-         }
-
-         if (s.value <= 0)
-         {
-             throw std::runtime_error{"value must be a positive integer"};
-         }
-     }},
-
-    // Performing string -> int conversion
-    {"--repetitions", [](settings::benchmark_settings &s, const std::string &arg)
-     {
-         int reps_arg = stoi(arg);
-         if (reps_arg > 0)
-         {
-             s.repetitions = reps_arg;
-         }
-         else
-         {
-             throw std::runtime_error{"repetitions must be a positive integer"};
-         }
-     }},
-    // Performing string -> int conversion
-    {"--warmup-repetitions", [](settings::benchmark_settings &s, const std::string &arg)
-     {
-         int reps_arg = stoi(arg);
-         if (reps_arg > 0)
-         {
-             s.warmup_repetitions = reps_arg;
-         }
-         else
-         {
-             throw std::runtime_error{"repetitions must be a positive integer"};
-         }
-     }},
-};
-#undef S
-
 // Parse the command line arguments
-settings::benchmark_settings settings::parse_settings(int argc, const char *argv[])
+void BenchmarkSettings::parse_settings(int argc, const char *argv[])
 {
-    benchmark_settings settings;
-
     for (int i{1}; i < argc; i++)
     {
         std::string opt{argv[i]};
 
         // NoArg
         if (auto j{NoArgs.find(opt)}; j != NoArgs.end())
-            j->second(settings); // Yes, handle it!
+            j->second(*this); // Yes, handle it!
 
         // OneArg
         else if (auto k{OneArgs.find(opt)}; k != OneArgs.end())
             // Yes, do we have a parameter?
             if (++i < argc)
                 // Yes, handle it!
-                k->second(settings, {argv[i]});
+                k->second(*this, {argv[i]});
             else
                 // No, and we cannot continue, throw an error
                 throw std::runtime_error{"missing param after " + opt};
@@ -136,6 +25,4 @@ settings::benchmark_settings settings::parse_settings(int argc, const char *argv
         else
             throw std::runtime_error{"unrecognized command-line option " + opt};
     }
-
-    return settings;
 }


### PR DESCRIPTION
Varios cambios para hacer de BenchmarkSettings una clase y así poder implementar subclases en las que añadir argumentos que sean específicos de uno o varios benchmarks.