### PR TITLE
Refactor/ping pong mejoras

### DIFF
--- a/benchmarks/ping_pong/mpi_ping_pong.cpp
+++ b/benchmarks/ping_pong/mpi_ping_pong.cpp
@@ -1,16 +1,25 @@
 #include <mpi.h>
 #include <mpi_benchmark_scheme.hpp>
+#include <ping_pong_settings.hpp>
 #include <iostream>
+#include <algorithm>
 
 class MpiPingPong : public MpiBenchmarkScheme
 {
 public:
-    uint32_t ping_pong_value;
+    PingPongSettings *ping_pong_settings;
+
+    uint32_t block_size{1};
+    std::vector<uint32_t> ping_pong_values;
     int neighbor_rank;
+
+    MpiPingPong() : MpiBenchmarkScheme(ping_pong_settings = new PingPongSettings()) {}
 
     void init(int argc, char *argv[]) override
     {
         MpiBenchmarkScheme::init(argc, argv);
+
+        block_size = ping_pong_settings->block_size.has_value() ? ping_pong_settings->block_size.value() : 1;
 
         if (world_size != 2)
         {
@@ -22,8 +31,8 @@ public:
             std::exit(1);
         }
 
-        // Int to increase
-        ping_pong_value = 0;
+        // Int block to increase
+        ping_pong_values.resize(block_size, 0);
 
         // Rank to send to and receive from
         neighbor_rank = (world_rank + 1) % 2;
@@ -35,12 +44,14 @@ public:
         {
             if (world_rank == i % 2)
             {
-                ping_pong_value++;
-                MPI_Send(&ping_pong_value, 1, MPI_INT, neighbor_rank, 0, MPI_COMM_WORLD);
+                // std::transform(ping_pong_values.begin(), ping_pong_values.end(), ping_pong_values.begin(), [](int n)
+                //                { return n + 1; });
+                ping_pong_values[0]++;
+                MPI_Send(ping_pong_values.data(), ping_pong_values.size(), MPI_INT, neighbor_rank, 0, MPI_COMM_WORLD);
             }
             else
             {
-                MPI_Recv(&ping_pong_value, 1, MPI_INT, neighbor_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                MPI_Recv(ping_pong_values.data(), ping_pong_values.size(), MPI_INT, neighbor_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
             }
         }
     }
@@ -49,9 +60,14 @@ public:
     {
         if (world_rank == 0)
         {
-            // std::cout << "Final value: " << ping_pong_value << std::endl;
+            // std::cout << "Final values: " << std::endl;
+            // for (auto num : ping_pong_values)
+            // {
+            //     std::cout << num << ", ";
+            // }
+            // std::cout << std::endl;
             // Reset counter
-            ping_pong_value = 0;
+            std::fill(ping_pong_values.begin(), ping_pong_values.end(), 0);
         }
     }
 };

--- a/benchmarks/ping_pong/upcxx_ping_pong_rpc.cpp
+++ b/benchmarks/ping_pong/upcxx_ping_pong_rpc.cpp
@@ -42,11 +42,11 @@ public:
             {
                 (*ping_pong_object)++;
                 upcxx::rpc(
-                    neighbor_rank, [](const uint32_t &value, upcxx::dist_object<uint32_t> &ping_pong_object, bool &received_flag)
+                    neighbor_rank, [](const uint32_t &value, upcxx::dist_object<uint32_t> &ping_pong_object)
                     {
                         *ping_pong_object = value;
                         received_flag = true; },
-                    *ping_pong_object, ping_pong_object, received_flag)
+                    *ping_pong_object, ping_pong_object)
                     .wait();
             }
             else

--- a/benchmarks/ping_pong/upcxx_ping_pong_rpc_no_flag.cpp
+++ b/benchmarks/ping_pong/upcxx_ping_pong_rpc_no_flag.cpp
@@ -1,16 +1,25 @@
 #include <upcxx/upcxx.hpp>
 #include <upcxx_benchmark_scheme.hpp>
+#include <ping_pong_settings.hpp>
 #include <iostream>
 
 class UpcxxPingPongRpcNoFlag : public UpcxxBenchmarkScheme
 {
 public:
     int neighbor_rank;
-    upcxx::dist_object<uint32_t> ping_pong_object;
+    PingPongSettings *ping_pong_settings;
+
+    uint32_t block_size{1};
+    uint32_t *ping_pong_values;
+    upcxx::dist_object<uint32_t *> ping_pong_object;
+
+    UpcxxPingPongRpcNoFlag() : UpcxxBenchmarkScheme(ping_pong_settings = new PingPongSettings()) {}
 
     void init(int argc, char *argv[]) override
     {
         UpcxxBenchmarkScheme::init(argc, argv);
+
+        block_size = ping_pong_settings->block_size.has_value() ? ping_pong_settings->block_size.value() : 1;
 
         if (world_size != 2)
         {
@@ -24,7 +33,12 @@ public:
 
         neighbor_rank = (world_rank + 1) % 2;
 
-        ping_pong_object = upcxx::dist_object<uint32_t>(0);
+        ping_pong_object = upcxx::dist_object<uint32_t *>(new uint32_t[block_size]);
+        ping_pong_values = *ping_pong_object;
+        for (size_t i = 0; i < block_size; i++)
+        {
+            ping_pong_values[i] = 0;
+        }
     };
 
     void benchmark_body() override
@@ -37,17 +51,18 @@ public:
 
             if (world_rank == i % 2)
             {
-                (*ping_pong_object)++;
+                ping_pong_values[0]++;
                 upcxx::rpc(
-                    neighbor_rank, [](const uint32_t &value, upcxx::dist_object<uint32_t> &ping_pong_object)
-                    { *ping_pong_object = value; },
-                    *ping_pong_object, ping_pong_object)
+                    neighbor_rank, [](const uint32_t &value, upcxx::dist_object<uint32_t *> &ping_pong_object)
+                    { (*ping_pong_object)[0] = value; },
+                    ping_pong_values[0], ping_pong_object)
                     .wait();
             }
             else
             {
-                while (expected_count != *ping_pong_object)
+                while (expected_count != ping_pong_values[0])
                 {
+                    // std::cout << "Rank " << world_rank << " expected: " << expected_count << " object:" << ping_pong_values[0] << std::endl;
                     upcxx::progress();
                 }
             }
@@ -58,8 +73,14 @@ public:
 
     void reset_result() override
     {
+        // std::cout << "Final values: " << std::endl;
+        // for (size_t i = 0; i < block_size; i++)
+        // {
+        //     std::cout << ping_pong_values[i] << ", ";
+        // }
+        // std::cout << std::endl;
         // Reset counter
-        *ping_pong_object = 0;
+        ping_pong_values[0] = 0;
     }
 };
 

--- a/benchmarks/ping_pong/upcxx_ping_pong_rput.cpp
+++ b/benchmarks/ping_pong/upcxx_ping_pong_rput.cpp
@@ -45,9 +45,8 @@ public:
             if (world_rank == i % 2)
             {
                 (*ping_pong_value)++;
-                upcxx::rput(*ping_pong_value, neighbor_ping_pong_ptr, upcxx::remote_cx::as_rpc([](bool &received_flag)
-                                                                                               { received_flag = true; },
-                                                                                               received_flag));
+                upcxx::rput(*ping_pong_value, neighbor_ping_pong_ptr, upcxx::remote_cx::as_rpc([]()
+                                                                                               { received_flag = true; }));
             }
             else
             {

--- a/benchmarks/ping_pong/upcxx_ping_pong_rput.cpp
+++ b/benchmarks/ping_pong/upcxx_ping_pong_rput.cpp
@@ -1,5 +1,6 @@
 #include <upcxx/upcxx.hpp>
 #include <upcxx_benchmark_scheme.hpp>
+#include <ping_pong_settings.hpp>
 #include <iostream>
 
 bool received_flag = false;
@@ -7,17 +8,22 @@ bool received_flag = false;
 class UpcxxPingPongRput : public UpcxxBenchmarkScheme
 {
 public:
+    PingPongSettings *ping_pong_settings;
+
+    uint32_t block_size{1};
+
     int neighbor_rank;
     upcxx::dist_object<upcxx::global_ptr<uint32_t>> global_ping_pong_object;
-    uint32_t *ping_pong_value;
+    uint32_t *ping_pong_values;
     upcxx::global_ptr<uint32_t> neighbor_ping_pong_ptr;
 
-    // Flag to check if the message was received
-    // upcxx::dist_object<bool> received_flag;
+    UpcxxPingPongRput() : UpcxxBenchmarkScheme(ping_pong_settings = new PingPongSettings()) {}
 
     void init(int argc, char *argv[]) override
     {
         UpcxxBenchmarkScheme::init(argc, argv);
+
+        block_size = ping_pong_settings->block_size.has_value() ? ping_pong_settings->block_size.value() : 1;
 
         if (world_size != 2)
         {
@@ -31,11 +37,9 @@ public:
 
         neighbor_rank = (world_rank + 1) % 2;
 
-        global_ping_pong_object = upcxx::dist_object<upcxx::global_ptr<uint32_t>>(upcxx::new_<uint32_t>(0));
-        ping_pong_value = global_ping_pong_object->local();
+        global_ping_pong_object = upcxx::dist_object<upcxx::global_ptr<uint32_t>>(upcxx::new_array<uint32_t>(block_size));
+        ping_pong_values = global_ping_pong_object->local();
         neighbor_ping_pong_ptr = global_ping_pong_object.fetch(neighbor_rank).wait();
-
-        // received_flag = upcxx::dist_object<bool>(false);
     };
 
     void benchmark_body() override
@@ -44,9 +48,9 @@ public:
         {
             if (world_rank == i % 2)
             {
-                (*ping_pong_value)++;
-                upcxx::rput(*ping_pong_value, neighbor_ping_pong_ptr, upcxx::remote_cx::as_rpc([]()
-                                                                                               { received_flag = true; }));
+                ping_pong_values[0]++;
+                upcxx::rput(ping_pong_values, neighbor_ping_pong_ptr, block_size, upcxx::remote_cx::as_rpc([]()
+                                                                                                           { received_flag = true; }));
             }
             else
             {
@@ -62,8 +66,14 @@ public:
 
     void reset_result() override
     {
+        // std::cout << "Final values: " << std::endl;
+        // for (size_t i = 0; i < block_size; i++)
+        // {
+        //     std::cout << ping_pong_values[i] << ", ";
+        // }
+        // std::cout << std::endl;
         // Reset counter
-        (*ping_pong_value) = 0;
+        ping_pong_values[0] = 0;
     }
 };
 

--- a/include/ping_pong_settings.hpp
+++ b/include/ping_pong_settings.hpp
@@ -1,0 +1,29 @@
+#include <benchmark_settings.hpp>
+
+class PingPongSettings : public BenchmarkSettings
+{
+public:
+    std::optional<uint32_t> block_size;
+
+    PingPongSettings()
+    {
+        OneArgs["--block-size"] = [](BenchmarkSettings &s, const std::string &arg)
+        {
+            PingPongSettings &new_settings = static_cast<PingPongSettings &>(s);
+            std::optional<int> value = parseBytes(arg);
+            if (value.has_value())
+            {
+                new_settings.block_size = value;
+            }
+            else
+            {
+                new_settings.block_size = stoi(arg);
+            }
+
+            if (new_settings.block_size <= 0)
+            {
+                throw std::runtime_error{"value must be a positive integer"};
+            }
+        };
+    };
+};


### PR DESCRIPTION
- Entero a enviar entre procesos sustituido por un bloque de enteros
- Nueva flag --block-size <size> para controlar el tamaño del bloque de datos
- Flags que usaban dist_object sustituidas por variables globales