### PR TITLE
Refactor/plantilla de número de procesos requeridos

### DIFF
--- a/benchmarks/ping_pong/mpi_ping_pong.cpp
+++ b/benchmarks/ping_pong/mpi_ping_pong.cpp
@@ -13,23 +13,13 @@ public:
     std::vector<uint32_t> ping_pong_values;
     int neighbor_rank;
 
-    MpiPingPong() : MpiBenchmarkScheme(ping_pong_settings = new PingPongSettings()) {}
+    MpiPingPong() : MpiBenchmarkScheme(ping_pong_settings = new PingPongSettings(), 2) {}
 
     void init(int argc, char *argv[]) override
     {
         MpiBenchmarkScheme::init(argc, argv);
 
         block_size = ping_pong_settings->block_size.has_value() ? ping_pong_settings->block_size.value() : 1;
-
-        if (world_size != 2)
-        {
-            if (world_rank == 0)
-            {
-                std::cerr << "This benchmark must be run with 2 processes" << std::endl;
-            }
-            MPI_Finalize();
-            std::exit(1);
-        }
 
         // Int block to increase
         ping_pong_values.resize(block_size, 0);

--- a/benchmarks/ping_pong/upcxx_ping_pong_rpc.cpp
+++ b/benchmarks/ping_pong/upcxx_ping_pong_rpc.cpp
@@ -16,23 +16,13 @@ public:
     uint32_t *ping_pong_values;
     upcxx::dist_object<uint32_t *> ping_pong_object;
 
-    UpcxxPingPongRpc() : UpcxxBenchmarkScheme(ping_pong_settings = new PingPongSettings()) {}
+    UpcxxPingPongRpc() : UpcxxBenchmarkScheme(ping_pong_settings = new PingPongSettings(), 2) {}
 
     void init(int argc, char *argv[]) override
     {
         UpcxxBenchmarkScheme::init(argc, argv);
 
         block_size = ping_pong_settings->block_size.has_value() ? ping_pong_settings->block_size.value() : 1;
-
-        if (world_size != 2)
-        {
-            if (world_rank == 0)
-            {
-                std::cerr << "This benchmark must be run with 2 processes" << std::endl;
-            }
-            upcxx::finalize();
-            std::exit(1);
-        }
 
         neighbor_rank = (world_rank + 1) % 2;
 

--- a/benchmarks/ping_pong/upcxx_ping_pong_rpc_no_flag.cpp
+++ b/benchmarks/ping_pong/upcxx_ping_pong_rpc_no_flag.cpp
@@ -13,23 +13,13 @@ public:
     uint32_t *ping_pong_values;
     upcxx::dist_object<uint32_t *> ping_pong_object;
 
-    UpcxxPingPongRpcNoFlag() : UpcxxBenchmarkScheme(ping_pong_settings = new PingPongSettings()) {}
+    UpcxxPingPongRpcNoFlag() : UpcxxBenchmarkScheme(ping_pong_settings = new PingPongSettings(), 2) {}
 
     void init(int argc, char *argv[]) override
     {
         UpcxxBenchmarkScheme::init(argc, argv);
 
         block_size = ping_pong_settings->block_size.has_value() ? ping_pong_settings->block_size.value() : 1;
-
-        if (world_size != 2)
-        {
-            if (world_rank == 0)
-            {
-                std::cerr << "This benchmark must be run with 2 processes" << std::endl;
-            }
-            upcxx::finalize();
-            std::exit(1);
-        }
 
         neighbor_rank = (world_rank + 1) % 2;
 

--- a/benchmarks/ping_pong/upcxx_ping_pong_rput.cpp
+++ b/benchmarks/ping_pong/upcxx_ping_pong_rput.cpp
@@ -17,23 +17,13 @@ public:
     uint32_t *ping_pong_values;
     upcxx::global_ptr<uint32_t> neighbor_ping_pong_ptr;
 
-    UpcxxPingPongRput() : UpcxxBenchmarkScheme(ping_pong_settings = new PingPongSettings()) {}
+    UpcxxPingPongRput() : UpcxxBenchmarkScheme(ping_pong_settings = new PingPongSettings(), 2) {}
 
     void init(int argc, char *argv[]) override
     {
         UpcxxBenchmarkScheme::init(argc, argv);
 
         block_size = ping_pong_settings->block_size.has_value() ? ping_pong_settings->block_size.value() : 1;
-
-        if (world_size != 2)
-        {
-            if (world_rank == 0)
-            {
-                std::cerr << "This benchmark must be run with 2 processes" << std::endl;
-            }
-            upcxx::finalize();
-            std::exit(1);
-        }
 
         neighbor_rank = (world_rank + 1) % 2;
 

--- a/benchmarks/ping_pong/upcxx_ping_pong_rput_no_flag.cpp
+++ b/benchmarks/ping_pong/upcxx_ping_pong_rput_no_flag.cpp
@@ -15,23 +15,13 @@ public:
     uint32_t *ping_pong_values;
     upcxx::global_ptr<uint32_t> neighbor_ping_pong_ptr;
 
-    UpcxxPingPongRputNoFlag() : UpcxxBenchmarkScheme(ping_pong_settings = new PingPongSettings()) {}
+    UpcxxPingPongRputNoFlag() : UpcxxBenchmarkScheme(ping_pong_settings = new PingPongSettings(), 2) {}
 
     void init(int argc, char *argv[]) override
     {
         UpcxxBenchmarkScheme::init(argc, argv);
 
         block_size = ping_pong_settings->block_size.has_value() ? ping_pong_settings->block_size.value() : 1;
-
-        if (world_size != 2)
-        {
-            if (world_rank == 0)
-            {
-                std::cerr << "This benchmark must be run with 2 processes" << std::endl;
-            }
-            upcxx::finalize();
-            std::exit(1);
-        }
 
         neighbor_rank = (world_rank + 1) % 2;
 

--- a/benchmarks/remote_completion/upcxx_no_rpc.cpp
+++ b/benchmarks/remote_completion/upcxx_no_rpc.cpp
@@ -24,19 +24,11 @@ public:
     // Root pointer
     upcxx::global_ptr<uint32_t> root_ptr;
 
+    UpcxxNoRpc() : UpcxxBenchmarkScheme(2) {}
+
     void init(int argc, char *argv[]) override
     {
         UpcxxBenchmarkScheme::init(argc, argv);
-
-        if (world_size != 2)
-        {
-            if (world_rank == 0)
-            {
-                std::cerr << "This benchmark must be run with 2 processes" << std::endl;
-            }
-            upcxx::finalize();
-            std::exit(1);
-        }
 
         value_g = upcxx::dist_object<upcxx::global_ptr<uint32_t>>(upcxx::new_array<uint32_t>(number_count));
         value = value_g->local();

--- a/benchmarks/remote_completion/upcxx_rpc_dist_object.cpp
+++ b/benchmarks/remote_completion/upcxx_rpc_dist_object.cpp
@@ -14,19 +14,11 @@ public:
     // Root pointer
     upcxx::global_ptr<uint32_t> root_ptr;
 
+    UpcxxRpcDistObject() : UpcxxBenchmarkScheme(2) {}
+
     void init(int argc, char *argv[]) override
     {
         UpcxxBenchmarkScheme::init(argc, argv);
-
-        if (world_size != 2)
-        {
-            if (world_rank == 0)
-            {
-                std::cerr << "This benchmark must be run with 2 processes" << std::endl;
-            }
-            upcxx::finalize();
-            std::exit(1);
-        }
 
         value_g = upcxx::dist_object<upcxx::global_ptr<uint32_t>>(upcxx::new_array<uint32_t>(number_count));
         value = value_g->local();
@@ -60,8 +52,7 @@ public:
             for (uint32_t i = 0; i < number_count; i++)
             {
                 upcxx::rput(value[i], root_ptr + i, upcxx::remote_cx::as_rpc([](upcxx::dist_object<uint32_t> &count)
-                                                                             { (*count)++; },
-                                                                             count));
+                                                                             { (*count)++; }, count));
             }
         }
 

--- a/benchmarks/remote_completion/upcxx_rpc_global_var.cpp
+++ b/benchmarks/remote_completion/upcxx_rpc_global_var.cpp
@@ -14,19 +14,11 @@ public:
     // Root pointer
     upcxx::global_ptr<uint32_t> root_ptr;
 
+    UpcxxRpcGlobalVar() : UpcxxBenchmarkScheme(2) {}
+
     void init(int argc, char *argv[]) override
     {
         UpcxxBenchmarkScheme::init(argc, argv);
-
-        if (world_size != 2)
-        {
-            if (world_rank == 0)
-            {
-                std::cerr << "This benchmark must be run with 2 processes" << std::endl;
-            }
-            upcxx::finalize();
-            std::exit(1);
-        }
 
         value_g = upcxx::dist_object<upcxx::global_ptr<uint32_t>>(upcxx::new_array<uint32_t>(number_count));
         value = value_g->local();

--- a/benchmarks/remote_completion/upcxx_sender_promise.cpp
+++ b/benchmarks/remote_completion/upcxx_sender_promise.cpp
@@ -18,19 +18,11 @@ public:
     // Root pointer
     upcxx::global_ptr<uint32_t> root_ptr;
 
+    UpcxxSenderPromise() : UpcxxBenchmarkScheme(2) {}
+
     void init(int argc, char *argv[]) override
     {
         UpcxxBenchmarkScheme::init(argc, argv);
-
-        if (world_size != 2)
-        {
-            if (world_rank == 0)
-            {
-                std::cerr << "This benchmark must be run with 2 processes" << std::endl;
-            }
-            upcxx::finalize();
-            std::exit(1);
-        }
 
         value_g = upcxx::dist_object<upcxx::global_ptr<uint32_t>>(upcxx::new_array<uint32_t>(number_count));
         value = value_g->local();

--- a/include/benchmark_scheme.hpp
+++ b/include/benchmark_scheme.hpp
@@ -9,6 +9,7 @@ public:
     uint32_t number_count = 1024;
     uint32_t reps = 1;
     uint32_t warmup_repetitions = 10;
+    u_int32_t processes_required;
 
     // MPI and UPCXX world size and rank
     int world_size, world_rank;
@@ -19,8 +20,8 @@ public:
     // Timer wrapper with time measurements
     benchmark_timer timer;
 
-    BenchmarkScheme() : settings(new BenchmarkSettings()){};
-    BenchmarkScheme(BenchmarkSettings *settings) : settings(settings) {}
+    BenchmarkScheme(uint32_t processes = 0) : settings(new BenchmarkSettings()), processes_required(processes){};
+    BenchmarkScheme(BenchmarkSettings *settings, uint32_t processes = 0) : settings(settings), processes_required(processes) {}
     virtual ~BenchmarkScheme();
 
     // Initialize all data needed

--- a/include/mpi_benchmark_scheme.hpp
+++ b/include/mpi_benchmark_scheme.hpp
@@ -5,8 +5,8 @@
 class MpiBenchmarkScheme : public BenchmarkScheme
 {
 public:
-    MpiBenchmarkScheme() = default;
-    MpiBenchmarkScheme(BenchmarkSettings *settings) : BenchmarkScheme(settings){};
+    MpiBenchmarkScheme(uint32_t processes = 0) : BenchmarkScheme(processes){};
+    MpiBenchmarkScheme(BenchmarkSettings *settings, uint32_t processes = 0) : BenchmarkScheme(settings, processes){};
     virtual ~MpiBenchmarkScheme() = default;
 
     virtual void init(int argc, char *argv[]) override;

--- a/include/upcxx_benchmark_scheme.hpp
+++ b/include/upcxx_benchmark_scheme.hpp
@@ -5,8 +5,8 @@
 class UpcxxBenchmarkScheme : public BenchmarkScheme
 {
 public:
-    UpcxxBenchmarkScheme() = default;
-    UpcxxBenchmarkScheme(BenchmarkSettings *settings) : BenchmarkScheme(settings){};
+    UpcxxBenchmarkScheme(uint32_t processes = 0) : BenchmarkScheme(processes){};
+    UpcxxBenchmarkScheme(BenchmarkSettings *settings, uint32_t processses = 0) : BenchmarkScheme(settings, processses){};
     virtual ~UpcxxBenchmarkScheme() = default;
 
     virtual void init(int argc, char *argv[]) override;

--- a/lib/benchmark_scheme.cpp
+++ b/lib/benchmark_scheme.cpp
@@ -8,6 +8,19 @@ BenchmarkScheme::~BenchmarkScheme()
 
 void BenchmarkScheme::init(int argc, char *argv[])
 {
+    if (processes_required > 0)
+    {
+        if (world_size != processes_required)
+        {
+            if (world_rank == 0)
+            {
+                std::cerr << "This benchmark requires " << processes_required << " processes" << std::endl;
+            }
+            finalize();
+            exit(1);
+        }
+    }
+
     settings->parse_settings(argc, const_cast<const char **>(argv));
     if (settings->value.has_value())
     {


### PR DESCRIPTION
Implementado el requerimiento de procesos en BenchmarkScheme. El Nº de procesos requeridos se indica en el constructor, de manera que las clases de los benchmarks que tengan requerimiento de procesos deben implementar su constructor llamando al de BenchmarkScheme , pasando el nº de procesos requeridos como argumento.