### PR TITLE
Feature/tiempos multiples

### DIFF
--- a/include/benchmark_scheme.hpp
+++ b/include/benchmark_scheme.hpp
@@ -17,7 +17,7 @@ public:
     BenchmarkSettings *settings;
 
     // Timer wrapper with time measurements
-    benchmark_timer timer;
+    BenchmarkTimer timer;
 
     BenchmarkScheme() : settings(new BenchmarkSettings()){};
     BenchmarkScheme(BenchmarkSettings *settings) : settings(settings) {}

--- a/include/benchmark_timer.hpp
+++ b/include/benchmark_timer.hpp
@@ -5,7 +5,9 @@
 #include <chrono>
 #include <vector>
 
-class benchmark_timer
+constexpr const char TIMER_END[] = "End";
+
+class BenchmarkTimer
 {
 private:
     // Start and end timepoints
@@ -14,12 +16,14 @@ private:
     BenchmarkSettings *m_settings;
 
 public:
-    std::vector<double> m_times;
+    std::unordered_map<std::string, std::vector<double>> m_times;
 
-    benchmark_timer(BenchmarkSettings *p_settings = nullptr);
-    benchmark_timer(const int32_t p_size, BenchmarkSettings *p_settings = nullptr);
+    BenchmarkTimer(BenchmarkSettings *p_settings = nullptr);
+    BenchmarkTimer(const int32_t p_size, BenchmarkSettings *p_settings = nullptr);
 
     void set_settings(BenchmarkSettings *p_settings);
+
+    void add_time_point(const std::string &p_name);
 
     void reserve(const int32_t p_size);
 
@@ -29,15 +33,15 @@ public:
     // Stop the timer
     void stop();
 
-    void add_time();
+    void add_time(std::string p_time_point = TIMER_END);
 
     void print_times();
 
     void reset_times();
 
-    double get_average_time();
+    double get_average_time(std::string p_time_point = TIMER_END);
 
-    double get_min_time();
+    double get_min_time(std::string p_time_point = TIMER_END);
 
     // Get the time in seconds
     double get_time();

--- a/lib/benchmark_timer.cpp
+++ b/lib/benchmark_timer.cpp
@@ -66,9 +66,23 @@ void BenchmarkTimer::print_times()
     {
         if (m_settings->raw_value)
             std::cout << "Count: " << m_settings->raw_value.value() << std::endl;
-        std::cout << "Repetitions: " << m_settings->repetitions.value_or(1) << std::endl;
-        std::cout << "Average times: " << this->get_average_time() << std::endl;
-        std::cout << "Min time: " << this->get_min_time() << std::endl;
+
+        std::cout << "Repetitions: " << m_settings->repetitions.value_or(1)
+                  << std::endl
+                  << std::endl;
+
+        std::cout << "Average times: " << std::endl;
+        for (auto time_point : m_times)
+            std::cout << time_point.first << ": " << this->get_average_time(time_point.first) << std::endl;
+        std::cout << std::endl;
+
+        std::cout << "Min times: " << std::endl;
+        for (auto time_point : m_times)
+        {
+            std::cout << time_point.first << ": " << this->get_min_time(time_point.first) << std::endl;
+        }
+        std::cout << std::endl;
+
         std::cout << "Times:" << std::endl;
         if (!m_times.empty())
         {

--- a/lib/mpi_benchmark_scheme.cpp
+++ b/lib/mpi_benchmark_scheme.cpp
@@ -14,13 +14,18 @@ void MpiBenchmarkScheme::init(int argc, char *argv[])
 void MpiBenchmarkScheme::join_results()
 {
     barrier();
-    if (world_rank == 0)
+    for (auto time_point_pair : timer.m_times)
     {
-        MPI_Reduce(MPI_IN_PLACE, timer.m_times.data(), timer.m_times.size(), MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
-    }
-    else
-    {
-        MPI_Reduce(timer.m_times.data(), NULL, timer.m_times.size(), MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+        std::vector<double> time_point = time_point_pair.second;
+
+        if (world_rank == 0)
+        {
+            MPI_Reduce(MPI_IN_PLACE, time_point.data(), time_point.size(), MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+        }
+        else
+        {
+            MPI_Reduce(time_point.data(), NULL, time_point.size(), MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+        }
     }
 }
 

--- a/lib/mpi_benchmark_scheme.cpp
+++ b/lib/mpi_benchmark_scheme.cpp
@@ -16,7 +16,7 @@ void MpiBenchmarkScheme::join_results()
     barrier();
     for (auto time_point_pair : timer.m_times)
     {
-        std::vector<double> time_point = time_point_pair.second;
+        std::vector<double> &time_point = time_point_pair.second;
 
         if (world_rank == 0)
         {

--- a/lib/upcxx_benchmark_scheme.cpp
+++ b/lib/upcxx_benchmark_scheme.cpp
@@ -17,7 +17,7 @@ void UpcxxBenchmarkScheme::join_results()
 
     for (auto time_point_pair : timer.m_times)
     {
-        std::vector<double> time_point = time_point_pair.second;
+        std::vector<double> &time_point = time_point_pair.second;
         upcxx::reduce_one(time_point.data(), time_point.data(), time_point.size(), upcxx::op_fast_max, 0).wait();
     }
 }

--- a/lib/upcxx_benchmark_scheme.cpp
+++ b/lib/upcxx_benchmark_scheme.cpp
@@ -15,7 +15,11 @@ void UpcxxBenchmarkScheme::join_results()
 {
     barrier();
 
-    upcxx::reduce_one(timer.m_times.data(), timer.m_times.data(), timer.m_times.size(), upcxx::op_fast_max, 0).wait();
+    for (auto time_point_pair : timer.m_times)
+    {
+        std::vector<double> time_point = time_point_pair.second;
+        upcxx::reduce_one(time_point.data(), time_point.data(), time_point.size(), upcxx::op_fast_max, 0).wait();
+    }
 }
 
 void UpcxxBenchmarkScheme::barrier()


### PR DESCRIPTION
Implementados tiempos múltiples por benchmark. Sustituido el vector de tiempos por un unordered_map<std::string, std::vector<double>>. Este mapa se inicializa por defecto con el vector equivalente al que había antes, etiquetado con "End". Se adaptan las funciones asociadas al timer con un string como argumento opcional que corresponde con la key del mapa. La implementación de los test no cambia, pero se añade la posibilidad de añadir "time_points" (elementos del mapa) en las funciones de inicialización con timer.add_time_point(string), y de llamar a timer.stop() y timer.add_time(time_point) para medir tiempos adicionales dentro de benchmark_body.