### PR TITLE
Feature/opciones de tiempos por procesos

### DIFF
--- a/include/benchmark_settings.hpp
+++ b/include/benchmark_settings.hpp
@@ -92,7 +92,7 @@ public:
     std::optional<u_int32_t> repetitions;
     bool warmup{true};
     std::optional<u_int32_t> warmup_repetitions;
-    NodeMeasurementMode measurement_node{NodeMeasurementMode::root};
+    NodeMeasurementMode measurement_mode{NodeMeasurementMode::root};
 
     typedef std::function<void(BenchmarkSettings &)> NoArgHandle;
 // No argument flag behavior
@@ -176,10 +176,10 @@ public:
 
         {"--measurement-mode", [](BenchmarkSettings &s, const std::string &arg)
          {
-             s.measurement_node = parseNodeMeasurementMode(arg);
+             s.measurement_mode = parseNodeMeasurementMode(arg);
          }},
         {"-m", [](BenchmarkSettings &s, const std::string &arg)
-         { s.measurement_node = parseNodeMeasurementMode(arg); }}};
+         { s.measurement_mode = parseNodeMeasurementMode(arg); }}};
 #undef S
 
     // Parse the command line arguments

--- a/include/benchmark_settings.hpp
+++ b/include/benchmark_settings.hpp
@@ -93,6 +93,7 @@ public:
     bool warmup{true};
     std::optional<u_int32_t> warmup_repetitions;
     NodeMeasurementMode measurement_mode{NodeMeasurementMode::root};
+    bool show_headers{true};
 
     typedef std::function<void(BenchmarkSettings &)> NoArgHandle;
 // No argument flag behavior
@@ -112,7 +113,8 @@ public:
         S("--quiet", o_mode, BenchmarkSettings::OutputMode::quiet),
         S("-q", o_mode, BenchmarkSettings::OutputMode::quiet),
 
-        S("--no-warmup", warmup, false)};
+        S("--no-warmup", warmup, false),
+        S("--no-headers", show_headers, false)};
 #undef S
 
     typedef std::function<void(BenchmarkSettings &, const std::string &)> OneArgHandle;

--- a/include/benchmark_settings.hpp
+++ b/include/benchmark_settings.hpp
@@ -43,6 +43,46 @@ public:
         quiet
     };
 
+    // Which nodes will measure time and how
+    enum class NodeMeasurementMode
+    {
+        root,
+        all,
+        max,
+        min,
+        avg
+    };
+
+private:
+    static NodeMeasurementMode parseNodeMeasurementMode(const std::string &arg)
+    {
+        if (arg == "root")
+        {
+            return NodeMeasurementMode::root;
+        }
+        else if (arg == "all")
+        {
+            return NodeMeasurementMode::all;
+        }
+        else if (arg == "max")
+        {
+            return NodeMeasurementMode::max;
+        }
+        else if (arg == "min")
+        {
+            return NodeMeasurementMode::min;
+        }
+        else if (arg == "avg")
+        {
+            return NodeMeasurementMode::avg;
+        }
+        else
+        {
+            throw std::runtime_error{"measurement-mode must be one of root, all, max, min, avg"};
+        }
+    }
+
+public:
     // bool help{false};
     // bool verbose{false};
     OutputMode o_mode{OutputMode::none};
@@ -52,7 +92,7 @@ public:
     std::optional<u_int32_t> repetitions;
     bool warmup{true};
     std::optional<u_int32_t> warmup_repetitions;
-    bool measure_max_time{false};
+    NodeMeasurementMode measurement_node{NodeMeasurementMode::root};
 
     typedef std::function<void(BenchmarkSettings &)> NoArgHandle;
 // No argument flag behavior
@@ -72,9 +112,7 @@ public:
         S("--quiet", o_mode, BenchmarkSettings::OutputMode::quiet),
         S("-q", o_mode, BenchmarkSettings::OutputMode::quiet),
 
-        S("--no-warmup", warmup, false),
-        S("--max-time", measure_max_time, true),
-    };
+        S("--no-warmup", warmup, false)};
 #undef S
 
     typedef std::function<void(BenchmarkSettings &, const std::string &)> OneArgHandle;
@@ -135,7 +173,13 @@ public:
                  throw std::runtime_error{"repetitions must be a positive integer"};
              }
          }},
-    };
+
+        {"--measurement-mode", [](BenchmarkSettings &s, const std::string &arg)
+         {
+             s.measurement_node = parseNodeMeasurementMode(arg);
+         }},
+        {"-m", [](BenchmarkSettings &s, const std::string &arg)
+         { s.measurement_node = parseNodeMeasurementMode(arg); }}};
 #undef S
 
     // Parse the command line arguments

--- a/include/benchmark_timer.hpp
+++ b/include/benchmark_timer.hpp
@@ -35,7 +35,7 @@ public:
 
     void add_time(std::string p_time_point = TIMER_END);
 
-    void print_times();
+    void print_times(int world_rank = 0);
 
     void reset_times();
 

--- a/lib/benchmark_scheme.cpp
+++ b/lib/benchmark_scheme.cpp
@@ -59,7 +59,7 @@ void BenchmarkScheme::run_benchmark(bool use_barrier)
     }
 
     // Start clock
-    if (world_rank == 0 || settings->measure_max_time)
+    if (world_rank == 0 || settings->measurement_node != BenchmarkSettings::NodeMeasurementMode::root)
     {
         timer.start();
     }
@@ -67,7 +67,7 @@ void BenchmarkScheme::run_benchmark(bool use_barrier)
     benchmark_body();
 
     // End clock
-    if (world_rank == 0 || settings->measure_max_time)
+    if (world_rank == 0 || settings->measurement_node != BenchmarkSettings::NodeMeasurementMode::root)
     {
         timer.stop();
         timer.add_time();
@@ -103,7 +103,7 @@ void BenchmarkScheme::run(int argc, char *argv[])
         run_benchmark();
     }
 
-    if (settings->measure_max_time)
+    if (settings->measurement_node != BenchmarkSettings::NodeMeasurementMode::root)
     {
         // if (world_rank)
         // {

--- a/lib/benchmark_scheme.cpp
+++ b/lib/benchmark_scheme.cpp
@@ -44,7 +44,7 @@ void BenchmarkScheme::init(int argc, char *argv[])
         warmup_repetitions = settings->warmup_repetitions.value();
     }
 
-    if (world_rank == 0)
+    if (world_rank == 0 || settings->measurement_mode != BenchmarkSettings::NodeMeasurementMode::root)
     {
         timer.reserve(reps);
         timer.set_settings(settings);
@@ -59,7 +59,7 @@ void BenchmarkScheme::run_benchmark(bool use_barrier)
     }
 
     // Start clock
-    if (world_rank == 0 || settings->measurement_node != BenchmarkSettings::NodeMeasurementMode::root)
+    if (world_rank == 0 || settings->measurement_mode != BenchmarkSettings::NodeMeasurementMode::root)
     {
         timer.start();
     }
@@ -67,7 +67,7 @@ void BenchmarkScheme::run_benchmark(bool use_barrier)
     benchmark_body();
 
     // End clock
-    if (world_rank == 0 || settings->measurement_node != BenchmarkSettings::NodeMeasurementMode::root)
+    if (world_rank == 0 || settings->measurement_mode != BenchmarkSettings::NodeMeasurementMode::root)
     {
         timer.stop();
         timer.add_time();
@@ -78,9 +78,9 @@ void BenchmarkScheme::run_benchmark(bool use_barrier)
 
 void BenchmarkScheme::print_results()
 {
-    if (world_rank == 0)
+    if (world_rank == 0 || settings->measurement_mode == BenchmarkSettings::NodeMeasurementMode::all)
     {
-        timer.print_times();
+        timer.print_times(world_rank);
     }
 }
 
@@ -103,7 +103,8 @@ void BenchmarkScheme::run(int argc, char *argv[])
         run_benchmark();
     }
 
-    if (settings->measurement_node != BenchmarkSettings::NodeMeasurementMode::root)
+    if (settings->measurement_mode != BenchmarkSettings::NodeMeasurementMode::root &&
+        settings->measurement_mode != BenchmarkSettings::NodeMeasurementMode::all)
     {
         // if (world_rank)
         // {

--- a/lib/benchmark_timer.cpp
+++ b/lib/benchmark_timer.cpp
@@ -60,10 +60,12 @@ void BenchmarkTimer::add_time(std::string p_time_point)
     }
 }
 
-void BenchmarkTimer::print_times()
+void BenchmarkTimer::print_times(int world_rank)
 {
     if (m_settings->o_mode == BenchmarkSettings::OutputMode::none)
     {
+        std::cout << "Rank: " << world_rank << std::endl;
+
         if (m_settings->raw_value)
             std::cout << "Count: " << m_settings->raw_value.value() << std::endl;
 
@@ -107,7 +109,9 @@ void BenchmarkTimer::print_times()
             {
                 for (auto it = time_point.second.begin(); it != time_point.second.end(); ++it)
                 {
-                    std::cout << m_settings->raw_value.value_or("1K") << ", "
+                    // rank, size, time_point, repetition, time
+                    std::cout << world_rank << ", "
+                              << m_settings->value.value_or(1024) << ", "
                               << time_point.first << ", "
                               << std::distance(time_point.second.begin(), it) + 1 << ", "
                               << *it

--- a/lib/benchmark_timer.cpp
+++ b/lib/benchmark_timer.cpp
@@ -105,6 +105,10 @@ void BenchmarkTimer::print_times(int world_rank)
     {
         if (!m_times.empty())
         {
+            if (world_rank == 0 && m_settings->show_headers)
+            {
+                std::cout << "Rank, Size, Timepoint, Index, Time" << std::endl;
+            }
             for (auto time_point : m_times)
             {
                 for (auto it = time_point.second.begin(); it != time_point.second.end(); ++it)

--- a/lib/mpi_benchmark_scheme.cpp
+++ b/lib/mpi_benchmark_scheme.cpp
@@ -14,17 +14,45 @@ void MpiBenchmarkScheme::init(int argc, char *argv[])
 void MpiBenchmarkScheme::join_results()
 {
     barrier();
+
+    MPI_Op op;
+
+    switch (settings->measurement_node)
+    {
+    case BenchmarkSettings::NodeMeasurementMode::max:
+        op = MPI_MAX;
+        break;
+    case BenchmarkSettings::NodeMeasurementMode::min:
+        op = MPI_MIN;
+        break;
+    case BenchmarkSettings::NodeMeasurementMode::avg:
+        op = MPI_SUM;
+        break;
+    default:
+        throw std::runtime_error("Invalid measurement mode");
+        break;
+    }
+
     for (auto time_point_pair : timer.m_times)
     {
         std::vector<double> &time_point = time_point_pair.second;
 
         if (world_rank == 0)
         {
-            MPI_Reduce(MPI_IN_PLACE, time_point.data(), time_point.size(), MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+            MPI_Reduce(MPI_IN_PLACE, time_point.data(), time_point.size(), MPI_DOUBLE, op, 0, MPI_COMM_WORLD);
+
+            if (settings->measurement_node == BenchmarkSettings::NodeMeasurementMode::avg)
+            {
+                // Compute the average
+                for (double &value : time_point)
+                {
+                    value /= world_size;
+                }
+            }
         }
         else
         {
-            MPI_Reduce(time_point.data(), NULL, time_point.size(), MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+            MPI_Reduce(time_point.data(), NULL, time_point.size(), MPI_DOUBLE, op, 0, MPI_COMM_WORLD);
         }
     }
 }

--- a/lib/mpi_benchmark_scheme.cpp
+++ b/lib/mpi_benchmark_scheme.cpp
@@ -17,23 +17,24 @@ void MpiBenchmarkScheme::join_results()
 
     MPI_Op op;
 
-    switch (settings->measurement_node)
+    if (settings->measurement_mode == BenchmarkSettings::NodeMeasurementMode::max)
     {
-    case BenchmarkSettings::NodeMeasurementMode::max:
         op = MPI_MAX;
-        break;
-    case BenchmarkSettings::NodeMeasurementMode::min:
+    }
+    else if (settings->measurement_mode == BenchmarkSettings::NodeMeasurementMode::min)
+    {
         op = MPI_MIN;
-        break;
-    case BenchmarkSettings::NodeMeasurementMode::avg:
+    }
+    else if (settings->measurement_mode == BenchmarkSettings::NodeMeasurementMode::avg)
+    {
         op = MPI_SUM;
-        break;
-    default:
+    }
+    else
+    {
         throw std::runtime_error("Invalid measurement mode");
-        break;
     }
 
-    for (auto time_point_pair : timer.m_times)
+    for (auto &time_point_pair : timer.m_times)
     {
         std::vector<double> &time_point = time_point_pair.second;
 
@@ -41,7 +42,7 @@ void MpiBenchmarkScheme::join_results()
         {
             MPI_Reduce(MPI_IN_PLACE, time_point.data(), time_point.size(), MPI_DOUBLE, op, 0, MPI_COMM_WORLD);
 
-            if (settings->measurement_node == BenchmarkSettings::NodeMeasurementMode::avg)
+            if (settings->measurement_mode == BenchmarkSettings::NodeMeasurementMode::avg)
             {
                 // Compute the average
                 for (double &value : time_point)

--- a/lib/upcxx_benchmark_scheme.cpp
+++ b/lib/upcxx_benchmark_scheme.cpp
@@ -15,6 +15,43 @@ void UpcxxBenchmarkScheme::join_results()
 {
     barrier();
 
+    switch (settings->measurement_node)
+    {
+    case BenchmarkSettings::NodeMeasurementMode::max:
+        for (auto time_point_pair : timer.m_times)
+        {
+            std::vector<double> &time_point = time_point_pair.second;
+            upcxx::reduce_one(time_point.data(), time_point.data(), time_point.size(), upcxx::op_fast_max, 0).wait();
+        }
+        break;
+    case BenchmarkSettings::NodeMeasurementMode::min:
+        for (auto time_point_pair : timer.m_times)
+        {
+            std::vector<double> &time_point = time_point_pair.second;
+            upcxx::reduce_one(time_point.data(), time_point.data(), time_point.size(), upcxx::op_fast_min, 0).wait();
+        }
+        break;
+    case BenchmarkSettings::NodeMeasurementMode::avg:
+        for (auto time_point_pair : timer.m_times)
+        {
+            std::vector<double> &time_point = time_point_pair.second;
+            upcxx::reduce_one(time_point.data(), time_point.data(), time_point.size(), upcxx::op_fast_add, 0).wait();
+
+            if (world_rank == 0)
+            {
+                // Compute the average
+                for (double &value : time_point)
+                {
+                    value /= world_size;
+                }
+            }
+        }
+        break;
+    default:
+        throw std::runtime_error("Invalid measurement mode");
+        break;
+    }
+
     for (auto time_point_pair : timer.m_times)
     {
         std::vector<double> &time_point = time_point_pair.second;

--- a/lib/upcxx_benchmark_scheme.cpp
+++ b/lib/upcxx_benchmark_scheme.cpp
@@ -15,47 +15,45 @@ void UpcxxBenchmarkScheme::join_results()
 {
     barrier();
 
-    switch (settings->measurement_node)
+    switch (settings->measurement_mode)
     {
     case BenchmarkSettings::NodeMeasurementMode::max:
-        for (auto time_point_pair : timer.m_times)
+        for (auto &time_point_pair : timer.m_times)
         {
             std::vector<double> &time_point = time_point_pair.second;
             upcxx::reduce_one(time_point.data(), time_point.data(), time_point.size(), upcxx::op_fast_max, 0).wait();
         }
         break;
     case BenchmarkSettings::NodeMeasurementMode::min:
-        for (auto time_point_pair : timer.m_times)
+        for (auto &time_point_pair : timer.m_times)
         {
             std::vector<double> &time_point = time_point_pair.second;
             upcxx::reduce_one(time_point.data(), time_point.data(), time_point.size(), upcxx::op_fast_min, 0).wait();
         }
         break;
     case BenchmarkSettings::NodeMeasurementMode::avg:
-        for (auto time_point_pair : timer.m_times)
+        for (auto &time_point_pair : timer.m_times)
         {
             std::vector<double> &time_point = time_point_pair.second;
-            upcxx::reduce_one(time_point.data(), time_point.data(), time_point.size(), upcxx::op_fast_add, 0).wait();
+            std::vector<double> time_point_aux(time_point.size());
+            upcxx::reduce_one(time_point.data(), time_point_aux.data(), time_point.size(), upcxx::op_fast_add, 0).wait();
 
             if (world_rank == 0)
             {
-                // Compute the average
-                for (double &value : time_point)
-                {
-                    value /= world_size;
-                }
+                time_point = time_point_aux;
+
+                if (settings->measurement_mode == BenchmarkSettings::NodeMeasurementMode::avg)
+                    // Compute the average
+                    for (double &value : time_point)
+                    {
+                        value /= world_size;
+                    }
             }
         }
         break;
     default:
         throw std::runtime_error("Invalid measurement mode");
         break;
-    }
-
-    for (auto time_point_pair : timer.m_times)
-    {
-        std::vector<double> &time_point = time_point_pair.second;
-        upcxx::reduce_one(time_point.data(), time_point.data(), time_point.size(), upcxx::op_fast_max, 0).wait();
     }
 }
 

--- a/new_mpi_sbatch.sh
+++ b/new_mpi_sbatch.sh
@@ -8,7 +8,6 @@
 
 
 NREPS=1
-IS_QUIET=0
 for i in "$@"; do
 	case $i in
     	-n=*|--nreps=*)
@@ -18,10 +17,6 @@ for i in "$@"; do
 		--sizes=*)
             SIZES_FILE="${i#*=}"
             shift # past argument=value
-            ;;
-        -q|--quiet)
-            IS_QUIET=1
-            shift # past argument with no value
             ;;
     	*)
         	# unknown option
@@ -47,21 +42,13 @@ export MPIRUN_CMD="srun -N $nodes -n %N --ntasks-per-node=$ntaskspernode -c $thr
 
 echo JOBID=$SLURM_JOB_ID
 
-if [[ $IS_QUIET -eq 0 ]]; then
-    echo Nodes=$nodes Procs=$procs TasksPerNode=$ntaskspernode ThreadsPerTask=$threads NREPS=$NREPS $*
-else
-    echo Size, Index, Time
-fi
+echo Nodes=$nodes Procs=$procs TasksPerNode=$ntaskspernode ThreadsPerTask=$threads NREPS=$NREPS $*
 
 # ulimit -s unlimited
 ulimit -c 0
 
 args=$@
-
-# Add -q to args if IS_QUIET is set
-if [[ $IS_QUIET -eq 1 ]]; then
-    args="$args -q"
-fi
+first=0
 
 if [[ -n $SIZES_FILE ]]; then
     for size in $(cat $SIZES_FILE);
@@ -69,6 +56,10 @@ if [[ -n $SIZES_FILE ]]; then
         # Add the --value $size argument
         cmd="$args --value $size"
         for ((i=1; i<=$NREPS; i++)); do
+            if [[ $first -eq 0 ]]; then
+                first=1
+            else
+                cmd="$cmd --noheader"
             # echo srun -N $nodes -n $procs --ntasks-per-node=$ntaskspernode $cmd
             srun -N $nodes -n $procs --ntasks-per-node=$ntaskspernode $cmd
         done

--- a/new_upcxx_sbatch.sh
+++ b/new_upcxx_sbatch.sh
@@ -57,7 +57,6 @@ ulimit -c 0
 args=$@
 first=0
 
-
 if [[ ${#files_for_args[@]} -eq 0 ]]; then
     for ((i=1; i<=$NREPS; i++)); do
         echo ${HOME}/new_upcxx_202403/bin/upcxx-run -N $nodes -n $procs $args
@@ -74,6 +73,7 @@ else
                     first=1
                 else
                     cmd="$cmd --no-headers"
+                fi
                 # echo ${HOME}/new_upcxx_202403/bin/upcxx-run -N $nodes -n $procs $cmd
                 ${HOME}/new_upcxx_202403/bin/upcxx-run -N $nodes -n $procs $cmd
             done


### PR DESCRIPTION
Cambios:
- "-q" eliminado de los argumentos de los scripts, ahora se usa sólo en los ejecutables.
- "--max-times" cambiado por "-m" o "--measurement-mode", seguido por "root", "max", "min", "avg" u "all".